### PR TITLE
Remove ec2:Describe*

### DIFF
--- a/resources/aws/iam/role/all_accounts/iambicspokerole.yaml
+++ b/resources/aws/iam/role/all_accounts/iambicspokerole.yaml
@@ -15,7 +15,6 @@ properties:
     - policy_name: base_permissions
       statement:
         - action:
-            - ec2:Describe*
             - iam:*
             - identitystore:*
             - organizations:describe*


### PR DESCRIPTION
I don't think it's necessary to have ec2:Describe* in the spoke role. 