### PR TITLE
Add cloudwatch_log_reader fixture that is available for all accounts

### DIFF
--- a/resources/aws/iam/user/all_accounts/account_name_cloudwatch_log_reader.yaml
+++ b/resources/aws/iam/user/all_accounts/account_name_cloudwatch_log_reader.yaml
@@ -1,0 +1,8 @@
+template_type: NOQ::AWS::IAM::User
+included_accounts:
+  - '*'
+identifier: '{{account_name}}_cloudwatch_log_reader'
+properties:
+  managed_policies:
+    - policy_arn: arn:aws:iam::aws:policy/CloudWatchApplicationInsightsReadOnlyAccess
+  user_name: '{{account_name}}_cloudwatch_log_reader'

--- a/resources/aws/iam/user/all_accounts/account_name_cloudwatch_log_reader.yaml
+++ b/resources/aws/iam/user/all_accounts/account_name_cloudwatch_log_reader.yaml
@@ -1,6 +1,4 @@
 template_type: NOQ::AWS::IAM::User
-included_accounts:
-  - '*'
 identifier: '{{account_name}}_cloudwatch_log_reader'
 properties:
   managed_policies:


### PR DESCRIPTION
I discovered there are functional tests expecting at least 1 user across the organization. This create a cloud watch log reader to fulfill that expectation.