### PR TITLE
Add engineering permission set

### DIFF
--- a/resources/aws/identity_center/engineering.yaml
+++ b/resources/aws/identity_center/engineering.yaml
@@ -1,0 +1,35 @@
+template_type: NOQ::AWS::IdentityCenter::PermissionSet
+access_rules:
+  - expires_at: in 4 years
+    groups:
+      - engineering
+identifier: engineering
+properties:
+  name: engineering
+  customer_managed_policy_references:
+    - name: base_deny
+      path: /
+  inline_policy:
+    statement:
+      - action:
+          - ec2:list*
+        effect: Deny
+        resource:
+          - '*'
+      - expires_at: in 6 years
+        action:
+          - ec2:list*
+        effect: Deny
+        resource:
+          - '*'
+  managed_policies:
+    - arn: arn:aws:iam::aws:policy/AWSHealthFullAccess
+      expires_at: in 5 years
+  permissions_boundary:
+    customer_managed_policy_reference:
+      name: base_permission_boundary
+      path: /
+  session_duration: PT4H
+  tags:
+    - key: owner
+      value: engineeringw@noq.dev

--- a/resources/aws/identity_center/engineering.yaml
+++ b/resources/aws/identity_center/engineering.yaml
@@ -1,6 +1,6 @@
 template_type: NOQ::AWS::IdentityCenter::PermissionSet
 access_rules:
-  - expires_at: in 4 years
+  - expires_at: 2027-05-19T14:37 UTC
     groups:
       - engineering
 identifier: engineering
@@ -16,15 +16,15 @@ properties:
         effect: Deny
         resource:
           - '*'
-      - expires_at: in 6 years
-        action:
+      - action:
           - ec2:list*
         effect: Deny
+        expires_at: 2029-05-19T14:37 UTC
         resource:
           - '*'
   managed_policies:
     - arn: arn:aws:iam::aws:policy/AWSHealthFullAccess
-      expires_at: in 5 years
+      expires_at: 2028-05-19T14:37 UTC
   permissions_boundary:
     customer_managed_policy_reference:
       name: base_permission_boundary


### PR DESCRIPTION
This is an example engineering permission set, demonstrating expiration for access rules, policy statements, and managed policy attachments.