### PR TITLE
Add Service Control Policies

### DIFF
--- a/resources/aws/organizations/scp/iambic_test_org_account/prevent_disable_security_services.yaml
+++ b/resources/aws/organizations/scp/iambic_test_org_account/prevent_disable_security_services.yaml
@@ -31,7 +31,6 @@ properties:
         effect: Deny
         resource:
           - '*'
-  policy_id: p-dbtm08da
   policy_name: PreventDisableSecurityServices
   targets:
     roots:

--- a/resources/aws/organizations/scp/iambic_test_org_account/prevent_disable_security_services.yaml
+++ b/resources/aws/organizations/scp/iambic_test_org_account/prevent_disable_security_services.yaml
@@ -1,0 +1,38 @@
+template_type: NOQ::AWS::Organizations::SCP
+account_id: '580605962305'
+iambic_managed: enforced
+identifier: PreventDisableSecurityServices
+org_id: o-8t0mt0ybdd
+properties:
+  policy_document:
+    statement:
+      - action:
+          - access-analyzer:DeleteAnalyzer
+          - ec2:DisableEbsEncryptionByDefault
+          - events:DeleteRule
+          - events:DisableRule
+          - events:RemoveTargets
+          - guardduty:CreateFilter
+          - guardduty:CreateIPSet
+          - guardduty:DeleteDetector
+          - guardduty:DisassociateFromMasterAccount
+          - guardduty:UpdateDetector
+          - s3:PutAccountPublicAccessBlock
+        effect: Deny
+        resource: '*'
+      - action:
+          - ec2:AcceptVpcPeeringConnection
+          - ec2:AttachInternetGateway
+          - ec2:CreateEgressOnlyInternetGateway
+          - ec2:CreateInternetGateway
+          - ec2:CreateVpcPeeringConnection
+          - globalaccelerator:Create*
+          - globalaccelerator:Update*
+        effect: Deny
+        resource:
+          - '*'
+  policy_id: p-dbtm08da
+  policy_name: PreventDisableSecurityServices
+  targets:
+    roots:
+      - r-dea5

--- a/resources/aws/organizations/scp/iambic_test_org_account/prevent_disable_security_services.yaml
+++ b/resources/aws/organizations/scp/iambic_test_org_account/prevent_disable_security_services.yaml
@@ -31,6 +31,7 @@ properties:
         effect: Deny
         resource:
           - '*'
+  policy_id: p-rmru2m06
   policy_name: PreventDisableSecurityServices
   targets:
     roots:

--- a/resources/aws/organizations/scp/iambic_test_org_account/prevent_imdsv1.yaml
+++ b/resources/aws/organizations/scp/iambic_test_org_account/prevent_imdsv1.yaml
@@ -35,6 +35,7 @@ properties:
         effect: Deny
         resource:
           - arn:aws:ec2:*:*:instance/*
+  policy_id: p-tvr71cki
   policy_name: PreventIMDSV1
   targets:
     roots:

--- a/resources/aws/organizations/scp/iambic_test_org_account/prevent_imdsv1.yaml
+++ b/resources/aws/organizations/scp/iambic_test_org_account/prevent_imdsv1.yaml
@@ -1,0 +1,42 @@
+template_type: NOQ::AWS::Organizations::SCP
+account_id: '580605962305'
+iambic_managed: enforced
+identifier: PreventIMDSV1
+org_id: o-8t0mt0ybdd
+properties:
+  policy_document:
+    statement:
+      - action:
+          - '*'
+        condition:
+          NumericLessThan:
+            Ec2RoleDelivery: '2.0'
+        effect: Deny
+        resource:
+          - '*'
+      - action:
+          - ec2:RunInstances
+        condition:
+          StringNotEquals:
+            Ec2MetadataHttpTokens: required
+        effect: Deny
+        resource:
+          - arn:aws:ec2:*:*:instance/*
+      - action:
+          - ec2:ModifyInstanceMetadataOptions
+        effect: Deny
+        resource:
+          - '*'
+      - action:
+          - ec2:RunInstances
+        condition:
+          NumericGreaterThan:
+            Ec2MetadataHttpPutResponseHopLimit: '1'
+        effect: Deny
+        resource:
+          - arn:aws:ec2:*:*:instance/*
+  policy_id: p-7t0nhw7s
+  policy_name: PreventIMDSV1
+  targets:
+    roots:
+      - r-dea5

--- a/resources/aws/organizations/scp/iambic_test_org_account/prevent_imdsv1.yaml
+++ b/resources/aws/organizations/scp/iambic_test_org_account/prevent_imdsv1.yaml
@@ -35,7 +35,6 @@ properties:
         effect: Deny
         resource:
           - arn:aws:ec2:*:*:instance/*
-  policy_id: p-7t0nhw7s
   policy_name: PreventIMDSV1
   targets:
     roots:

--- a/resources/aws/organizations/scp/iambic_test_org_account/prevent_root_login.yaml
+++ b/resources/aws/organizations/scp/iambic_test_org_account/prevent_root_login.yaml
@@ -1,0 +1,22 @@
+template_type: NOQ::AWS::Organizations::SCP
+account_id: '580605962305'
+iambic_managed: enforced
+org_id: o-8t0mt0ybdd
+identifier: DontRootMe
+properties:
+  policy_document:
+    statement:
+      - action:
+          - '*'
+        condition:
+          StringLike:
+            aws:PrincipalArn:
+              - arn:aws:iam::*:root
+        effect: Deny
+        resource:
+          - '*'
+  policy_id: p-0rwoirln
+  policy_name: DontRootMe
+  targets:
+    roots:
+      - r-dea5

--- a/resources/aws/organizations/scp/iambic_test_org_account/prevent_root_login.yaml
+++ b/resources/aws/organizations/scp/iambic_test_org_account/prevent_root_login.yaml
@@ -1,8 +1,8 @@
 template_type: NOQ::AWS::Organizations::SCP
 account_id: '580605962305'
 iambic_managed: enforced
-org_id: o-8t0mt0ybdd
 identifier: DontRootMe
+org_id: o-8t0mt0ybdd
 properties:
   policy_document:
     statement:
@@ -15,6 +15,7 @@ properties:
         effect: Deny
         resource:
           - '*'
+  policy_id: p-gkhvx8m5
   policy_name: DontRootMe
   targets:
     roots:

--- a/resources/aws/organizations/scp/iambic_test_org_account/prevent_root_login.yaml
+++ b/resources/aws/organizations/scp/iambic_test_org_account/prevent_root_login.yaml
@@ -15,7 +15,6 @@ properties:
         effect: Deny
         resource:
           - '*'
-  policy_id: p-0rwoirln
   policy_name: DontRootMe
   targets:
     roots:

--- a/resources/aws/organizations/scp/iambic_test_org_account/restrict_regions.yaml
+++ b/resources/aws/organizations/scp/iambic_test_org_account/restrict_regions.yaml
@@ -34,7 +34,6 @@ properties:
           - wellarchitected:*
         resource:
           - '*'
-  policy_id: p-g9vrcqin
   policy_name: RestrictRegions
   targets:
     roots:

--- a/resources/aws/organizations/scp/iambic_test_org_account/restrict_regions.yaml
+++ b/resources/aws/organizations/scp/iambic_test_org_account/restrict_regions.yaml
@@ -34,6 +34,7 @@ properties:
           - wellarchitected:*
         resource:
           - '*'
+  policy_id: p-usy2yicd
   policy_name: RestrictRegions
   targets:
     roots:

--- a/resources/aws/organizations/scp/iambic_test_org_account/restrict_regions.yaml
+++ b/resources/aws/organizations/scp/iambic_test_org_account/restrict_regions.yaml
@@ -1,0 +1,41 @@
+template_type: NOQ::AWS::Organizations::SCP
+account_id: '580605962305'
+iambic_managed: enforced
+identifier: RestrictRegions
+org_id: o-8t0mt0ybdd
+properties:
+  policy_document:
+    statement:
+      - condition:
+          StringNotEquals:
+            aws:RequestedRegion:
+              - us-east-1
+              - us-west-2
+        effect: Deny
+        not_action:
+          - a4b:*
+          - budgets:*
+          - ce:*
+          - chime:*
+          - cloudfront:*
+          - cur:*
+          - globalaccelerator:*
+          - health:*
+          - iam:*
+          - importexport:*
+          - mobileanalytics:*
+          - organizations:*
+          - route53:*
+          - route53domains:*
+          - shield:*
+          - support:*
+          - trustedadvisor:*
+          - waf:*
+          - wellarchitected:*
+        resource:
+          - '*'
+  policy_id: p-g9vrcqin
+  policy_name: RestrictRegions
+  targets:
+    roots:
+      - r-dea5


### PR DESCRIPTION
This PR introduces basic service control policies to serve as example compliance guardrails across multiple AWS accounts in an organization.